### PR TITLE
AJAX requests to authenticated resources now use Bearer Token

### DIFF
--- a/src/main/webapp/public/js/dukecloak.js
+++ b/src/main/webapp/public/js/dukecloak.js
@@ -16,8 +16,12 @@ var dukecloak = {
 		dukecloak.keycloakAuth.loadUserProfile().success(function(profile){
 			dukecloak.auth.username(profile.username);
 			console.log("Logged in: " + dukecloak.auth.username());
-            $.ajax({
+            dukecloak.keycloakAuth.updateToken().success(function() {$.ajax({
                 method: 'GET',
+                beforeSend: function (request)
+                {
+                    request.setRequestHeader("Authorization", 'Bearer ' + dukecloak.keycloakAuth.token);
+                },
                 dataType: "json",
                 url: preferencesUrl,
                 success: function(data) {
@@ -26,10 +30,13 @@ var dukecloak = {
                         return fav.eventId;
                     });
                     dukeconSettings.saveSetting(dukeconSettings.fav_key, favourites);
-                    window.location.reload();
+                    /* TODO: can't do a page reload here as it would result in an infinite loop,
+                    instead put the favourites into the view model directly
+                    */ 
+                    // window.location.reload();
                 },
                 error: function() { console.log("Error loading preferences");}
-            });
+            })}).error(function() { console.log("Unable to update token");});
 		});
     },
 

--- a/src/main/webapp/public/js/offline.js
+++ b/src/main/webapp/public/js/offline.js
@@ -231,6 +231,9 @@ var dukeconSettings = {
 var dukeconSynch = {
 
     push : function() {
+        if (!dukecloak.keycloakAuth.authenticated) {
+            return;
+        }
         var successCallback = function() {
             console.log("Success!");
         };
@@ -242,14 +245,18 @@ var dukeconSynch = {
         _.each(localFavourites, function(fav) {
             favourites.push({"eventId" : fav, "version" : "1"})
         });
-        $.ajax({
+        dukecloak.keycloakAuth.updateToken().success(function() {$.ajax({
             method: 'POST',
+            beforeSend: function (request)
+            {
+                request.setRequestHeader("Authorization", 'Bearer ' + dukecloak.keycloakAuth.token);
+            },
             contentType : "application/json",
             data : JSON.stringify(favourites),
             url: "rest/preferences",
             success: successCallback,
             error: errorCallback
-        });
+        })}).error(errorCallback);
     }
 };
 


### PR DESCRIPTION
They also update the bearer token as necessary.

TODO: dukecloak.js:33 needs to be enhanced to publish the loaded favourites to the view model directly instead of a window reload (would otherwise lead to a infinite loop)
