### PR TITLE
set status to online on initial caching of application

### DIFF
--- a/src/main/webapp/public/js/offline.js
+++ b/src/main/webapp/public/js/offline.js
@@ -20,6 +20,9 @@ window.addEventListener('load', function(e) {
     window.applicationCache.addEventListener("error", function(e) {
        setOfflineStatus(true);
     });
+    window.applicationCache.addEventListener("cached", function(e) {
+        setOfflineStatus(false);
+    });
     window.applicationCache.addEventListener("noupdate", function(e) {
         setOfflineStatus(false);
     });


### PR DESCRIPTION
I found that with Chrome and not authenticated the timer to retrieve updated talks didn't start as this event was missing
@annam002 - please have a look and merge.
